### PR TITLE
Fixes #34 floating status bars don't update

### DIFF
--- a/Source/GASShooter/Private/Characters/Heroes/GSHeroCharacter.cpp
+++ b/Source/GASShooter/Private/Characters/Heroes/GSHeroCharacter.cpp
@@ -811,13 +811,14 @@ void AGSHeroCharacter::InitializeFloatingStatusBar()
 			UIFloatingStatusBar = CreateWidget<UGSFloatingStatusBarWidget>(PC, UIFloatingStatusBarClass);
 			if (UIFloatingStatusBar && UIFloatingStatusBarComponent)
 			{
+				// Set owner before construction
+				UIFloatingStatusBar->OwningCharacter = this;
 				UIFloatingStatusBarComponent->SetWidget(UIFloatingStatusBar);
 
 				// Setup the floating status bar
 				UIFloatingStatusBar->SetHealthPercentage(GetHealth() / GetMaxHealth());
 				UIFloatingStatusBar->SetManaPercentage(GetMana() / GetMaxMana());
 				UIFloatingStatusBar->SetShieldPercentage(GetShield() / GetMaxShield());
-				UIFloatingStatusBar->OwningCharacter = this;
 				UIFloatingStatusBar->SetCharacterName(CharacterName);
 			}
 		}


### PR DESCRIPTION
Sets owner before UI_FloatingStatusBar_Hero blueprint construction event is hit and prevents failure due to missing owning character.

If I'm being honest I don't totally understand when the blueprint constructor is being called but I think I lucked into fixing this one by moving the line up.